### PR TITLE
#1271 Fixed Flaky Test

### DIFF
--- a/compiler/src/main/java/org/robovm/compiler/config/Config.java
+++ b/compiler/src/main/java/org/robovm/compiler/config/Config.java
@@ -81,6 +81,7 @@ import org.robovm.compiler.util.InfoPList;
 import org.robovm.compiler.util.io.RamDiskTools;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Serializer;
 import org.simpleframework.xml.convert.Converter;
@@ -96,6 +97,7 @@ import org.simpleframework.xml.stream.OutputNode;
  * Holds compiler configuration.
  */
 @Root
+@Order(elements = {"os", "arch", "forceLinkClasses", "libs", "frameworks", "resources", "classpath", "target" ,"iosSdkVersion", "iosInfoPList", "iosEntitlementsPList"})
 public class Config {
 
     /**

--- a/compiler/src/main/java/org/robovm/compiler/config/Resource.java
+++ b/compiler/src/main/java/org/robovm/compiler/config/Resource.java
@@ -27,6 +27,7 @@ import org.robovm.compiler.target.Target;
 import org.robovm.compiler.util.AntPathMatcher;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Order;
 
 /**
  * Specifies resources needed by the application the compiler produces. A
@@ -129,6 +130,7 @@ import org.simpleframework.xml.ElementList;
  * </ul>
  * </p>
  */
+@Order(elements = {"targetPath", "directory", "includes", "excludes", "flatten"})
 public class Resource {
 
     /**


### PR DESCRIPTION
The test compiler/src/test/java/org/robovm/compiler/config/ConfigTest.java passed using normal maven-test, but showed Non-deterministic behavior under NonDex(https://github.com/TestingResearchIllinois/NonDex) and thus failed. The cause of failure is due to the non-determinstic ordering of the xml strings and thus this fix converts the order of xml strings to a deterministic one.